### PR TITLE
chore(test): do not log error in test

### DIFF
--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -152,9 +152,7 @@ describe('<Link>', () => {
         )
     })
     test('throws error with an invalid route', () => {
-        jest.spyOn(global.console, 'error').mockImplementationOnce(() =>
-            jest.fn(),
-        )
+        jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn())
         expect(() => {
             render(
                 <Provider url='/' routes={routes}>

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -21,6 +21,9 @@ import {
 import { useOatmilk } from '../hooks'
 
 afterEach(cleanup)
+afterEach(() => {
+    jest.clearAllMocks()
+})
 
 const homeRoute: IRoute = {
     name: 'home',


### PR DESCRIPTION
This also resets all mocks after each test, so our console.error spy will be reset too.